### PR TITLE
Upgrade to rake-compiler-dock 1.1.0

### DIFF
--- a/bcrypt_pbkdf.gemspec
+++ b/bcrypt_pbkdf.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '>= 5'
   s.add_development_dependency 'openssl'
   s.add_development_dependency 'rdoc', '~> 3.12'
-  s.add_development_dependency 'rake-compiler-dock', '~> 1.0.1'
+  s.add_development_dependency 'rake-compiler-dock', '~> 1.1.0'
 
   s.has_rdoc = true
   s.rdoc_options += ['--title', 'bcrypt_pbkdf', '--line-numbers', '--inline-source', '--main', 'README.md']


### PR DESCRIPTION
Upgrade `rake-compiler-dock` 1.1.0

```sh
<= 1.8.6 : unsupported
 = 1.8.7 : gem install rdoc-data; rdoc-data --install
 = 1.9.1 : gem install rdoc-data; rdoc-data --install
>= 1.9.2 : nothing to do! Yay!
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /Users/boga/Work/OSS/NetSSH/bcrypt_pbkdf-ruby/bcrypt_pbkdf.gemspec:19.
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from bcrypt_pbkdf.gemspec:19.
no configuration section for specified version of Ruby (rbconfig-x86-mingw32-2.2.2)
no configuration section for specified version of Ruby (rbconfig-x86-mingw32-2.1.6)
no configuration section for specified version of Ruby (rbconfig-x86-mingw32-2.0.0)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-3.0.0)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.7.0)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.6.0)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.5.0)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.4.0)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.3.0)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.2.2)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.1.6)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.0.0)
rake aborted!
Don't know how to build task 'native' (See the list of available tasks with `rake --tasks`)
/usr/local/rvm/gems/ruby-2.5.8/gems/rake-compiler-1.1.1/lib/rake/extensiontask.rb:456:in `block in define_cross_platform_tasks_with_version'
/usr/local/rvm/gems/ruby-2.5.8/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.5.8/bin/ruby_executable_hooks:24:in `eval'
/usr/local/rvm/gems/ruby-2.5.8/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => cross
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [docker run -v /Users/boga/Work/OSS/NetSSH/bcrypt_pbkdf-ruby:/Users/boga/Work/OSS/NetSSH/bcrypt_pbkdf-ruby -e UID\=1000 -e GID\=1000 -e USER\=boga -e GROUP\=_staff -e GEM_PRIVATE_KEY_PASSPHRASE -e ftp_proxy -e http_proxy -e https_proxy -e RCD_HOST_RUBY_PLATFORM\=x86_64-darwin20 -e RCD_HOST_RUBY_VERSION\=2.6.5 -e RCD_IMAGE\=larskanis/rake-compiler-dock-mri-x86-mingw32:1.1.0 -w /Users/boga/Work/OSS/NetSSH/bcrypt_pbkdf-ruby --rm -i -t larskanis/rake-compiler-dock-mri-x86-mingw32:1.1.0 runas sigfw bash -c bundle\ \&\&\ rake\ cross\ native\ gem\ RUBY_CC_VERSION\=3.0.0:2.7.0:2.6.0:2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0]
```