### PR TITLE
Test: use recent Minitest style

### DIFF
--- a/test/bcrypt_pnkdf/engine_test.rb
+++ b/test/bcrypt_pnkdf/engine_test.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'minitest/unit'
 require 'test_helper'
 
 # bcrypt_pbkdf in ruby
@@ -54,7 +55,7 @@ def bcrypt_pbkdf(password, salt, keylen, rounds)
 end
 
 
-class TestExt < MiniTest::Unit::TestCase
+class TestExt < Minitest::Unit::TestCase
   def test_table
     assert_equal table, table.map{ |p,s,l,r| [p,s,l,r,BCryptPbkdf::Engine::__bc_crypt_pbkdf(p,s,l,r).bytes] }
   end


### PR DESCRIPTION
Current style has long been to use Minitest instead of MiniTest at least for 3 years, and with minitest 5.19, MiniTest usage support is hidden unless explicitly setting ENV["MT_COMPAT"].

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6

Use Minitest and explicitly require 'minitest/unit' .