### PR TITLE
add tests for invalid keylen guard (issue #31/#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,18 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake compile
       - run: bundle exec rake test
+
+  memcheck:
+    name: Memory leak check (valgrind)
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: Gemfile.memcheck
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - run: sudo apt-get install -y valgrind
+      - run: bundle exec rake compile
+      - run: bundle exec rake memcheck

--- a/Gemfile.memcheck
+++ b/Gemfile.memcheck
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'ruby_memcheck'

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,15 @@ require 'rdoc/task'
 require 'benchmark'
 require 'rake_compiler_dock'
 
+begin
+  require 'ruby_memcheck'
+  RubyMemcheck::TestTask.new(memcheck: :compile) do |t|
+    t.libs << 'test'
+    t.test_files = FileList['test/**/*_test.rb']
+  end
+rescue LoadError
+end
+
 CLEAN.add("{ext,lib}/**/*.{o,so}", "pkg")
 
 cross_rubies = ["3.4.0", "3.3.0", "3.2.0", "3.1.0", "3.0.0", "2.7.0"]

--- a/test/bcrypt_pnkdf/engine_test.rb
+++ b/test/bcrypt_pnkdf/engine_test.rb
@@ -66,6 +66,21 @@ class TestExt < Minitest::Test
   end
 
 
+  # Issue #31/33: xmalloc(okeylen) was called before the guards inside
+  # bcrypt_pbkdf(), so out-of-range keylen caused a heap allocation that was
+  # never freed when bcrypt_pbkdf() returned -1. `loop { key("p","s",2000,1) }`
+  # on unfixed code would exhaust memory.
+  def test_invalid_keylen_returns_nil
+    assert_nil BCryptPbkdf::Engine.__bc_crypt_pbkdf("pass", "salt", 0, 1)
+    assert_nil BCryptPbkdf::Engine.__bc_crypt_pbkdf("pass", "salt", 1025, 1)
+    assert_nil BCryptPbkdf::Engine.__bc_crypt_pbkdf("pass", "salt", 2000, 1)
+    assert_nil BCryptPbkdf::Engine.__bc_crypt_pbkdf("pass", "salt", 32, 0)
+  end
+
+  def test_invalid_keylen_does_not_leak_memory
+    1000.times { BCryptPbkdf::Engine.__bc_crypt_pbkdf("pass", "salt", 2000, 1) }
+  end
+
   def table
     [
       ["pass2", "salt2", 12, 2, [214, 14, 48, 162, 131, 206, 121, 176, 50, 104, 231, 252]],


### PR DESCRIPTION
Adds regression tests and a valgrind-based CI job for the memory leaks fixed in #34.

**Tests** (`test_invalid_keylen_returns_nil`, `test_invalid_keylen_does_not_leak_memory`): verify that `keylen=0`, `keylen>1024`, and `rounds=0` return nil, and that repeated calls with an out-of-range keylen don't leak.

**Memcheck CI job**: runs the test suite under valgrind via `ruby_memcheck` on Ubuntu. On unfixed code, each call to `__bc_crypt_pbkdf("pass", "salt", 2000, 1)` leaks 2000 bytes (`xmalloc` before the guard, no `xfree` on the error path); the 1000-iteration test produces ~2MB of reported leaks and fails the job. With #34's fix applied the guard fires before `xmalloc` and the job passes.

`Gemfile.memcheck` keeps `ruby_memcheck` out of the main bundle (it requires Ruby >= 3.0, the project supports 2.7).