### PR TITLE
sync blf.h to OpenBSD v1.8 (drop advertising clause)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The C sources are synced from openssh-portable, which tracks OpenBSD CVS:
 |------|----------------|
 | `ext/mri/bcrypt_pbkdf.c` | [v1.17](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libutil/bcrypt_pbkdf.c?rev=1.17) |
 | `ext/mri/blowfish.c` | [v1.20](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libcrypto/blowfish.c?rev=1.20) |
+| `ext/mri/blf.h` | [v1.8](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libcrypto/blf.h?rev=1.8) |
 
 ## Links
 

--- a/ext/mri/blf.h
+++ b/ext/mri/blf.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: blf.h,v 1.7 2007/03/14 17:59:41 grunk Exp $ */
+/* $OpenBSD: blf.h,v 1.8 2021/11/29 01:04:45 djm Exp $ */
 /*
  * Blowfish - a fast block cipher designed by Bruce Schneier
  *
@@ -13,10 +13,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *      This product includes software developed by Niels Provos.
- * 4. The name of the author may not be used to endorse or promote products
+ * 3. The name of the author may not be used to endorse or promote products
  *    derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR


### PR DESCRIPTION
`blf.h` was still at v1.7 with the 4-clause BSD advertising clause. This syncs it to v1.8 (same commit as `blowfish.c` v1.20, already done in #36).

Closes #19 — the `blowfish.c` half of that PR was already applied in #36; this covers the `blf.h` half.