### PR TITLE
include java gem in gem:all and gem:release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -105,11 +105,18 @@ namespace "gem" do
     Rake::Task["pkg/#{GEMSPEC.full_name}-java.gem"].invoke
   end
 
+  namespace "java" do
+    task "release" do
+      sh "gem push pkg/#{GEMSPEC.full_name}-java.gem"
+    end
+  end
+
   desc "build native gem for all platforms"
   task "all" do
     cross_platforms.each do |platform|
       Rake::Task["gem:#{platform}"].invoke
     end
+    Rake::Task["gem:java"].invoke if defined?(Rake::JavaExtensionTask)
   end
 
   desc "release native gem for all platforms"
@@ -117,6 +124,7 @@ namespace "gem" do
     cross_platforms.each do |platform|
       Rake::Task["gem:#{platform}:release"].invoke
     end
+    Rake::Task["gem:java:release"].invoke if defined?(Rake::JavaExtensionTask)
   end
 end
 


### PR DESCRIPTION
Extends the two release tasks so the Java gem is built and published alongside the MRI platform gems.

- `gem:all` now calls `gem:java` (guarded by `defined?(Rake::JavaExtensionTask)`)
- `gem:release` now calls `gem:java:release` (new subtask that pushes the `-java.gem`)

Without this, the existing `publish-bcrypt-release` workflow builds and publishes MRI gems only, leaving JRuby users with no platform gem.

Depends on #30.